### PR TITLE
Issue #15: Extreme FiveFieldKono

### DIFF
--- a/FiveFieldKono.hs
+++ b/FiveFieldKono.hs
@@ -7,7 +7,8 @@ import System.Random (getStdGen,randoms)
 
 -- Se crea el tipo FiveFieldKono.
 
-data FiveFieldKono = FiveFieldKono Int [Piece]
+-- ++ Ahora FiveFieldKono tiene jugador, numero de turno y una lista de piezas ++
+data FiveFieldKono = FiveFieldKono Int Int [Piece]
 
 boardX :: Int
 boardX = 5
@@ -35,9 +36,12 @@ inStartPos (x,y)
 -- Se hace que FiveFieldKono sea instancia de Game y se definen las funciones necesarias.
 
 instance Game FiveFieldKono where
-    current (FiveFieldKono c _) = c
-
-    winner (FiveFieldKono c pc) mvs
+    current (FiveFieldKono c _ _) = c
+    winner (FiveFieldKono c turn pc) mvs
+        -- ++ Si jugador 0 tiene sus espacios usados y el turno es mayor a 4, pierde ++
+        | turn > 8 && all (\(x,y) -> pieceAt (x,y) pc /= Nothing) [(0,3),(0,4),(1,4),(2,4),(3,4),(4,3),(4,4)] = Just 1
+        -- ++ Si jugador 1 tiene sus espacios usados y el turno es mayor a 4, pierde ++
+        | turn > 9 && all (\(x,y) -> pieceAt (x,y) pc /= Nothing) [(0,1),(0,0),(1,0),(2,0),(3,0),(4,0),(4,1)] = Just 0
         -- Si el jugador actual no tiene movimientos, gana el otro
         | null mvs = Just (1 - c)
         -- Si todas las piezas del jugador0 están en las posiciones iniciales del jugador1, gana
@@ -47,7 +51,7 @@ instance Game FiveFieldKono where
         -- Si ninguna se cumple, se sigue jugando
         | otherwise = Nothing
 
-    movements st@(FiveFieldKono c pc) = let
+    movements st@(FiveFieldKono c _ pc) = let
         playerpcs = filter (\(p,x,y,k) -> p == c) pc
         in concatMap (pieceMoves st) playerpcs
 
@@ -56,9 +60,9 @@ instance Game FiveFieldKono where
     Recibe un juego FiveFieldKono y una pieza.
     Retorna un movimiento, que consiste de un comando y el nuevo estado del juego.
 -}
-
+-- ++ Los movimientos tambien tienen un contador de turno aumentado en 1
 pieceMoves :: FiveFieldKono -> Piece -> [(String,FiveFieldKono)]
-pieceMoves (FiveFieldKono c pcs) (p,x,y,k) = let
+pieceMoves (FiveFieldKono c turn pcs) (p,x,y,k) = let
     -- Posibles posiciones a las que moverse
     steps = [(x-1,y-1),(x-1,y+1),(x+1,y-1),(x+1,y+1)]
     -- Checkear si es posible moverse a una posición
@@ -66,12 +70,12 @@ pieceMoves (FiveFieldKono c pcs) (p,x,y,k) = let
         pieceAt (xf,yf) pcs == Nothing && 0 <= xf && xf < boardX && 0 <= yf && yf < boardY
     -- Generar los posibles movimientos
     steps2 = filter isValid steps
-    in [(moveName (x,y) (xf,yf), FiveFieldKono (1-c) (movePiece (x,y) (xf,yf) pcs)) | (xf,yf) <- steps2]
+    in [(moveName (x,y) (xf,yf), FiveFieldKono (1-c) (turn+1) (movePiece (x,y) (xf,yf) pcs)) | (xf,yf) <- steps2]
 
 -- Se define como se transforma un FiveFieldKono a String.
 
 instance Show FiveFieldKono where
-    show (FiveFieldKono _ pcs) = let
+    show (FiveFieldKono c turn pcs) = let
         draw (x,y) = case pieceAt (x,y) pcs of
             Just (0,_,_,_) -> "⚉ "
             Just (1,_,_,_) -> "⚇ "
@@ -79,12 +83,15 @@ instance Show FiveFieldKono where
                 | inStartPos (x,y) == 0 -> "◡ "
                 | inStartPos (x,y) == 1 -> "◠ "
                 | otherwise             -> "  "
-        in drawBoard (boardX,boardY) draw
+        -- ++ Aqui se concadena el turno actual, al string de drawboard. ++
+        extra = if turn >= 8 then ": Sudden Death!" else ""
+        turno = if (c == 0) then "Turno: " ++ show (div turn 2) ++ extra else ""
+        in drawBoard (boardX,boardY) draw ++ turno
 
 -- Inicialización del juego.
-
+-- ++ Inicializamos con turno = 0 ++
 fiveFieldKonoIni :: FiveFieldKono
-fiveFieldKonoIni = FiveFieldKono 0 [(p,x,y,'K') |
+fiveFieldKonoIni = FiveFieldKono 0 0 [(p,x,y,'K') |
     x<-[0..boardX-1], y<-[0..boardY-1], let p = inStartPos (x,y), p>=0]
 
 -- Main.
@@ -97,7 +104,7 @@ main = do
     let seed = head (randoms gen)
     putStrLn $ "Seed: " ++ show seed
     -- Crear jugadores
-    let player0 = cpuRand "Walter White"
+    let player0 = human "Walter White"
     let player1 = cpuRand "Jack Black"
     --Jugar
     execute fiveFieldKonoIni [player0,player1] seed


### PR DESCRIPTION
Se agrego un nuevo parametro al estado de FiveFieldKono, un Int que denota el numero de turno en el que van.
(FiveFieldKono Int [Piece]) es ahora (FiveFieldKono Int Int [Piece]).
En la funcion winner se agregó la nueva win-condition: Pierde el jugador cuyos espacios iniciales han sido ocupados (Sin importar por quien), pero solo si el turno actual es mayor a 4.
Se modificó pieceMoves para que todos los estados nuevos posibles tengan (turno + 1).
Se modificó show para que, además del tablero, muestre en pantalla el turno actual en el que están. Desde el cuarto turno mostrará también un mensaje que dice: "SUDDEN DEATH!", para indicar que desde el proximo turno se aplicará la nueva win-condition.