### PR TITLE
Issue #16 Menu pre-partida + historial de partidas

### DIFF
--- a/FiveFieldKono.hs
+++ b/FiveFieldKono.hs
@@ -86,18 +86,31 @@ instance Show FiveFieldKono where
 fiveFieldKonoIni :: FiveFieldKono
 fiveFieldKonoIni = FiveFieldKono 0 [(p,x,y,'K') |
     x<-[0..boardX-1], y<-[0..boardY-1], let p = inStartPos (x,y), p>=0]
+{-
+    Esta funcion solo existe para evitarme un error, lo que hace no tiene nada relevante, incluso es una copia de 
+    la funcion eval de fox and hounds. ya que al no tener una funcion eval propia tuve que "crear" una funcion para 
+    que no me diera error, pero al momento de generar los jugadores no tomara encuenta esta funcion 
+    y eligira una cpu random en su lugar.
+-}
+fiveFieldKonoEval :: FiveFieldKono -> Float
+fiveFieldKonoEval (FiveFieldKono c pcs) = let
+    fI = fromIntegral
+    fox@(_,fx,fy,_) = head (filter (\(p,_,_,_) -> p == 0) pcs)
+    houndsum = sum [if y>=fy then 0.5 else 0.05 * abs (fI x - fI fx) | (p,x,y,k) <- pcs, p==1]
+    in (houndsum + 7 - fI fy) * (if c==0 then 1.0 else -1.0)
 
 -- Main.
 
 main :: IO Int
 main = do
-    -- Inicialización del generador de números aleatorios
+    {-
+        Creo gen para poder usarla en la funcion fivefieldkono.
+    -}
     gen <- getStdGen
     -- Semilla aleatoria que se usará para el juego
     let seed = head (randoms gen)
     putStrLn $ "Seed: " ++ show seed
-    -- Crear jugadores
-    let player0 = cpuRand "Walter White"
-    let player1 = cpuRand "Jack Black"
-    --Jugar
-    execute fiveFieldKonoIni [player0,player1] seed
+    {-
+        Se llama a la funcion que nos piden.
+    -}
+    configAndExecute fiveFieldKonoIni seed "five Fiel dKono" fiveFieldKonoEval

--- a/FoxAndHounds.hs
+++ b/FoxAndHounds.hs
@@ -89,10 +89,9 @@ main = do
     -- Semilla aleatoria que se usará para el juego
     let seed = head (randoms gen)
     putStrLn $ "Seed: " ++ show seed
-    -- Crear jugadores
-    let player0 = cpuRand "Son"
-    let player1 = cpuEval "Father" foxAndHoundsEval
-    -- Jugar
-    execute foxAndHoundsIni [player0,player1] seed
+     {-
+        Se llama a la funcion que nos piden.
+    -}
+    configAndExecute foxAndHoundsIni seed "fox and hounds" foxAndHoundsEval 
 
 

--- a/Game.hs
+++ b/Game.hs
@@ -78,7 +78,6 @@ argmaxs xs = [i | (x,i) <- zip xs [0..], x >= maximum xs]
 cpuEval :: (Game s) => String -> (s -> Float) -> Player s
 cpuEval name eval = let
     pickCommand st mvs r = do
-        print ("hola")
         -- Encontrar que jugador soy
         let me = current st
         -- Función de evaluación para cualquier estado s, negada si cambia el jugador


### PR DESCRIPTION
Nombre: Roberto Covarrubias Figueroa
Rol: 201804181-5
Se modifica FoxAndHounds.hs y FiveFielKono.hs para que no se creen los jugadores con nombres predeterminados y se llama a la función pedida, configAndExecute, que tiene como parámetros el inicio del juego, la seed, el nombre del juego (que yo lo predetermino dentro del código), y la función eval para cpuEval, en este ultimo intente trabajar con Maybe ya que Five Field Kono no posee una función eval y tampoco cpuEval pero me fue imposible configurar mi código para que con Maybe pudiera recibir Nothing y evitar la creación  de fiveFieldKonoEval, que solo es la copia de la funcion foxAndHoundsEval, solo existe para evitar el error, la función fiveFieldKonoEval nunca sera llamada por ningún motivo, pero gracias al  "trucazo" anterior se pueden crear jugadores con cpuEval para fox And Hounds, para Five Field Kono tambien pero serán cpuRand.

En la función configAndExecute se piden los nombres de los jugadores por la consola y obtiene los tipos con la función auxiliar get_tipo que no posee parámetros y retorna IO String, y al volver a configAndExecute se llama a la funcion new_player_1 que mediante una guard creara al jugador correspondiente con su tipo ( human, cpuRand y cpuEval), posteriormente configAndExecute creara un historial con el nombre que se le indique.